### PR TITLE
hosted-git-info 3.0.5 removed support for node_js 6 and 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,5 +5,8 @@
     "remark-preset-lint-recommended": "^3.0.3",
     "remark-validate-links": "^10.0.0",
     "yaml-lint": "^1.2.4"
+  },
+  "resolutions": {
+    "**/hosted-git-info": "3.0.4"
   }
 }


### PR DESCRIPTION
Attempt to pin to previous version (rather than updating .travis.yml of all projects that use nmos-lint-scripts) as per https://classic.yarnpkg.com/en/docs/selective-version-resolutions/

See https://github.com/AMWA-TV/nmos-authorization/pull/48#issuecomment-659933045.