### PR TITLE
Lint SDP files with AMWA-TV/sdpoker

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
 set -o errexit
+set -o pipefail
+set -o nounset
 
 [ ! -e .scripts/package.json ] && echo Run this from the top-level directory && exit 1
 

--- a/lint.sh
+++ b/lint.sh
@@ -1,9 +1,15 @@
 #!/usr/bin/env bash
 
+set -o errexit
+set -o pipefail
+set -o nounset
+
 shopt -s globstar nullglob
 
 PATH=$PWD/node_modules/.bin:$PATH
 REMARKRC=$PWD/.scripts/.remarkrc
+
+failed=n
 
 cd ..
 
@@ -35,8 +41,8 @@ if [ -d APIs/schemas ]; then
             echo "$i" ok
         else
             echo -e "\033[31m$i failed\033[0m"
-        failed=y
-      fi
+            failed=y
+        fi
     done
 fi
 
@@ -47,8 +53,16 @@ if [ -d examples ]; then
             echo "$i" ok
         else
             echo -e "\033[31m$i failed\033[0m"
-        failed=y
-      fi
+            failed=y
+        fi
+    done
+    for i in examples/**/*.sdp ; do
+        if sdpoker "$i"; then
+            echo "$i" ok
+        else
+            echo -e "\033[31m$i failed\033[0m"
+            failed=y
+        fi
     done
 fi
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "remark-cli": "^7.0.1",
     "remark-preset-lint-recommended": "^3.0.3",
     "remark-validate-links": "^10.0.0",
+    "sdpoker": "AMWA-TV/sdpoker",
     "yaml-lint": "^1.2.4"
   },
   "resolutions": {


### PR DESCRIPTION
Fixes #11.

Tested locally by making a copy of https://github.com/AMWA-TV/bcp-006-01/blob/v1.0-dev/examples/jpeg-xs.sdp and removing the `mediaclk` attribute.